### PR TITLE
Experimental: test callback speed without handlescope or env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 fetch_package("github:holepunchto/libquickbit#5ecf908")
 fetch_package("github:holepunchto/libjstl#69d56e")
-# add_subdirectory("../libjstl" "${CMAKE_BINARY_DIR}/libjstl")
+#add_subdirectory("../libjstl" "${CMAKE_BINARY_DIR}/libjstl")
 
 add_bare_module(quickbit_native_bare)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ if(target MATCHES "win32")
 endif()
 
 fetch_package("github:holepunchto/libquickbit#5ecf908")
-# fetch_package("github:holepunchto/libjstl#71ab461")
-add_subdirectory("../libjstl" "${CMAKE_BINARY_DIR}/libjstl")
+fetch_package("github:holepunchto/libjstl#69d56e")
+# add_subdirectory("../libjstl" "${CMAKE_BINARY_DIR}/libjstl")
 
 add_bare_module(quickbit_native_bare)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ if(target MATCHES "win32")
 endif()
 
 fetch_package("github:holepunchto/libquickbit#5ecf908")
-fetch_package("github:holepunchto/libjstl#71ab461")
+# fetch_package("github:holepunchto/libjstl#71ab461")
+add_subdirectory("../libjstl" "${CMAKE_BINARY_DIR}/libjstl")
 
 add_bare_module(quickbit_native_bare)
 

--- a/binding.cc
+++ b/binding.cc
@@ -1,5 +1,4 @@
 #include <bare.h>
-#include <cstdint>
 #include <js.h>
 #include <jstl.h>
 #include <quickbit.h>

--- a/binding.cc
+++ b/binding.cc
@@ -282,9 +282,36 @@ quickbit_napi_skip_last(
   return quickbit_skip_last((uint8_t *) index, len, value, position);
 }
 
+
+static uint8_t *input_buffer;
+static const size_t input_length = 1 << 20;
+
+static inline int32_t
+quickbit_napi_find_first_envless(
+  js_receiver_t,
+  uint32_t len,
+  uint32_t value,
+  int32_t position
+) {
+  return quickbit_find_first(input_buffer, len, value, position);
+}
+
+
 static js_value_t *
 quickbit_napi_exports(js_env_t *env, js_value_t *exports) {
   int err;
+
+  input_buffer = (uint8_t *) malloc(input_length);
+
+  js_value_t *input;
+  err = js_create_external_arraybuffer(env, input_buffer, input_length, NULL, NULL, &input);
+  assert(err == 0);
+  err = js_set_named_property(env, exports, "__input", input);
+  assert(err == 0);
+  err = js_set_property<quickbit_napi_find_first_envless, false, false>(env, exports, "quickbit_napi_find_first_envless");
+  assert(err == 0);
+
+  // ----------------
 
   err = js_set_property(env, exports, "sizeof_quickbit_index_t", uint32_t(sizeof(quickbit_index_t)));
   assert(err == 0);

--- a/binding.cc
+++ b/binding.cc
@@ -1,4 +1,5 @@
 #include <bare.h>
+#include <cstdint>
 #include <js.h>
 #include <jstl.h>
 #include <quickbit.h>
@@ -120,6 +121,28 @@ quickbit_napi_find_first(
   assert(err == 0);
 
   return quickbit_find_first(field.data(), field.size(), value, position);
+}
+
+static inline int32_t
+quickbit_napi_find_first_experimental(
+  js_env_t *env,
+  js_receiver_t,
+  js_object_t buffer,
+  uint32_t offset,
+  uint32_t len,
+  uint32_t value,
+  int32_t position
+) {
+  int err;
+
+  uint8_t *slab;
+  size_t slab_len;
+
+  err = js_get_arraybuffer_info(env, buffer, (void **) &slab, &slab_len);
+  assert(err == 0);
+  assert(offset + len <= slab_len);
+
+  return quickbit_find_first(slab + offset, len, value, position);
 }
 
 static inline int32_t
@@ -301,6 +324,9 @@ quickbit_napi_exports(js_env_t *env, js_value_t *exports) {
   assert(err == 0);
 
   err = js_set_property<quickbit_napi_skip_last>(env, exports, "quickbit_napi_skip_last");
+  assert(err == 0);
+
+  err = js_set_property<quickbit_napi_find_first_experimental, false, false>(env, exports, "quickbit_napi_find_first_experimental");
   assert(err == 0);
 
   return exports;

--- a/index.js
+++ b/index.js
@@ -40,7 +40,18 @@ exports.findFirst = function findFirst (field, value, position = 0) {
   if (position < 0) position = 0
   if (position >= n) return -1
 
-  return binding.quickbit_napi_find_first(toBuffer(field), value ? 1 : 0, position)
+  // return binding.quickbit_napi_find_first(toBuffer(field), value ? 1 : 0, position)
+
+  // experimental
+  let { buffer, byteOffset, byteLength } = field
+
+  if (!buffer && field instanceof ArrayBuffer) {
+    buffer = field
+    byteOffset ||= 0
+  }
+  // if (!buffer) throw new Error('invalid field')
+
+  return binding.quickbit_napi_find_first_experimental(buffer, byteOffset, byteLength, value ? 1 : 0, position)
 }
 
 exports.findLast = function findLast (field, value, position = field.byteLength * 8 - 1) {

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ exports.findFirst = function findFirst (field, value, position = 0) {
 
     // experimental (scopeless)
     case 1: {
+      return binding.quickbit_napi_find_first_scopeless(field.buffer, field.byteOffset || 0, field.byteLength, value ? 1 : 0, position)
+
       let { buffer, byteOffset, byteLength } = field
 
       if (!buffer && field instanceof ArrayBuffer) {
@@ -54,7 +56,7 @@ exports.findFirst = function findFirst (field, value, position = 0) {
         byteOffset ||= 0
       }
 
-      return binding.quickbit_napi_find_first_experimental(buffer, byteOffset, byteLength, value ? 1 : 0, position)
+      //return binding.quickbit_napi_find_first_experimental(buffer, byteOffset, byteLength, value ? 1 : 0, position)
     }
 
     // experimental (envless, scopeless)


### PR DESCRIPTION
ops per second for comparison:

- v2.3.6 (base) `4673406`
- fastcall-alpha (broken views) `7122507`
- v2.4.0 `5591324`
- Scopeless variant: `5808888` (expected more 700k)
- Envless variant (writes to external arraybuffer are slow) `155393`

temporary main switch: https://github.com/holepunchto/quickbit-native/pull/8/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R43