### PR TITLE
Update `libjstl` and use `js_typedarray_span_t`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(target MATCHES "win32")
 endif()
 
 fetch_package("github:holepunchto/libquickbit#5ecf908")
-fetch_package("github:holepunchto/libjstl#067e248")
+fetch_package("github:holepunchto/libjstl#2188770")
 
 add_bare_module(quickbit_native_bare)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(target MATCHES "win32")
 endif()
 
 fetch_package("github:holepunchto/libquickbit#5ecf908")
-fetch_package("github:holepunchto/libjstl#71ab461")
+fetch_package("github:holepunchto/libjstl#067e248")
 
 add_bare_module(quickbit_native_bare)
 


### PR DESCRIPTION
Current `main` crashes when entering the fast path as we're not allowed to open escapable handle scopes without a parent scope. https://github.com/holepunchto/libjstl/commit/21887703a5e4a5fa2118ecb2816e617f0f77385e addresses that.